### PR TITLE
bug fix:Vue is not defined when use webpack

### DIFF
--- a/src/EasyToast.vue
+++ b/src/EasyToast.vue
@@ -123,6 +123,7 @@
   }
 </style>
 <script>
+  const Vue = window.Vue
   const suppressWarn = Vue && Vue.version.startsWith('1.') ? { 'transition': { template: '<div><slot></slot></div>' } } : null
   const DEFAULT_OPT = {
     id: 'easy-toast-default',


### PR DESCRIPTION
When use webpack, you are in restrict mode, use undeclared variable Vue will result in error

need to declare it or use window.Vue